### PR TITLE
fix: ensure DataStoreFile does not convert to custom struct

### DIFF
--- a/lib/frontman/data_store_file.rb
+++ b/lib/frontman/data_store_file.rb
@@ -56,5 +56,10 @@ module Frontman
     def to_s
       "<DataStoreFile #{@data.keys.join(', ')} >"
     end
+
+    sig { returns(Frontman::DataStoreFile) }
+    def to_ostruct
+      self
+    end
   end
 end

--- a/spec/frontman/data_store_file_spec.rb
+++ b/spec/frontman/data_store_file_spec.rb
@@ -3,7 +3,17 @@
 
 require './spec/spec_setup'
 require 'lib/frontman/data_store_file'
+require 'lib/frontman/data_store'
 
 describe Frontman::DataStoreFile do
-  # TODO: determine best tests
+  subject do
+    data = Frontman::DataStore.new("#{__dir__}/mocks")
+    data.info
+  end
+
+  describe '#to_ostruct' do
+    it 'does not convert to custom struct' do
+      expect(subject.to_ostruct.is_a?(Frontman::DataStoreFile)).to eq true
+    end
+  end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no

## Description
This makes sure the `DataStoreFile` does not convert to custom structs when we call the `to_ostruct` method. This caused issues when we do a recursive `to_ostruct`, for example when we have these in arrays. 

## Tested
I've added unit tests for this method to ensure it works properly.

