### PR TITLE
fix: enable asset fingerprinting with config value

### DIFF
--- a/lib/frontman/builder/builder.rb
+++ b/lib/frontman/builder/builder.rb
@@ -96,7 +96,9 @@ module Frontman
           .returns(String)
       end
       def add_asset_to_manifest(manifest_path, file_path)
-        path_with_digest = manifest_path.sub(/\.(\w+)$/) { |ext| "-#{digest(file_path)}#{ext}" }
+        path_with_digest = manifest_path.sub(/\.(\w+)$/) do |ext|
+          "-#{digest(file_path)}#{ext}"
+        end
 
         Frontman::App.instance.add_to_manifest(manifest_path, path_with_digest)
         path_with_digest

--- a/lib/frontman/builder/builder.rb
+++ b/lib/frontman/builder/builder.rb
@@ -79,9 +79,27 @@ module Frontman
           .returns(Frontman::Builder::File)
       end
       def build_from_asset(path, manifest_path)
-        target_path = create_target_path(manifest_path)
+        target = manifest_path
+
+        if Frontman::Config.get(:fingerprint_assets, fallback: false)
+          path_with_digest = add_asset_to_manifest(manifest_path, path)
+          target = path_with_digest
+        end
+
+        target_path = create_target_path(target)
 
         build_from_content(target_path, ::File.read(path))
+      end
+
+      sig do
+        params(manifest_path: String, file_path: String)
+          .returns(String)
+      end
+      def add_asset_to_manifest(manifest_path, file_path)
+        path_with_digest = manifest_path.sub(/\.(\w+)$/) { |ext| "-#{digest(file_path)}#{ext}" }
+
+        Frontman::App.instance.add_to_manifest(manifest_path, path_with_digest)
+        path_with_digest
       end
 
       sig do

--- a/project-templates/webpack/config.rb
+++ b/project-templates/webpack/config.rb
@@ -16,6 +16,7 @@ add_asset_pipeline(
 
 Frontman::Config.set :public_dir, '.tmp/'
 Frontman::Config.set :domain, 'https://example.com'
+Frontman::Config.set :fingerprint_assets, true
 
 Frontman::Bootstrapper.resources_from_dir(
   'source/'

--- a/project-templates/webpack/package-lock.json
+++ b/project-templates/webpack/package-lock.json
@@ -3009,9 +3009,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -4354,9 +4354,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.memoize": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes

## Description
This allows you to enable asset fingerprinting (appending a hash of the file contents) with a config value, instead of having to override the `Builder` class.

