### PR TITLE
Add Dev Server Port Retry Strategy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
     - '**/Rakefile'
     - 'vendor/**/*'
 
+Style/Lambda:
+  Enabled: false
+
 Gemspec/RequiredRubyVersion:
   Exclude:
     - 'frontman-ssg.gemspec'

--- a/lib/frontman.rb
+++ b/lib/frontman.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'frontman/errors'
 require 'frontman/app'
 require 'frontman/context'
 require 'frontman/config'

--- a/lib/frontman/app.rb
+++ b/lib/frontman/app.rb
@@ -164,6 +164,5 @@ module Frontman
       local_data = @view_data.last[:locals]
       local_data[key] unless local_data.nil?
     end
-
   end
 end

--- a/lib/frontman/app.rb
+++ b/lib/frontman/app.rb
@@ -165,11 +165,5 @@ module Frontman
       local_data[key] unless local_data.nil?
     end
 
-    class ExistingResourceError < StandardError
-      def self.create(url, resource)
-        new("Unable to redirect for #{url},
-             the resource #{resource.file_path} already exists on this URL")
-      end
-    end
   end
 end

--- a/lib/frontman/commands/build.rb
+++ b/lib/frontman/commands/build.rb
@@ -52,7 +52,7 @@ module Frontman
       builder.build_directory = build_directory
       builder.current_build_files = current_build_files
 
-      builder.on('created, updated, deleted, unchanged', lambda { |build_file|
+      builder.on('created, updated, deleted, unchanged', ->(build_file) {
         mapping.add_from_build_file(build_file)
       })
 

--- a/lib/frontman/commands/serve.rb
+++ b/lib/frontman/commands/serve.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: false
 
+require 'socket'
 require 'thor'
 require 'sinatra/base'
 require 'better_errors'
@@ -70,11 +71,11 @@ module Frontman
 
       listener.start
 
-      FrontManServer.set :public_folder, Frontman::Config.get(
+      FrontmanServer.set :public_folder, Frontman::Config.get(
         :public_dir, fallback: 'public'
       )
-      FrontManServer.run! do
-        host = "http://localhost:#{FrontManServer.settings.port}"
+      FrontmanServer.run! do
+        host = "http://localhost:#{FrontmanServer.settings.port}"
         print "== View your site at \"#{host}/\"\n"
         processes += assets_pipeline.run_in_background!(:after)
         at_exit { processes.each { |pid| Process.kill(0, pid) } }
@@ -83,8 +84,34 @@ module Frontman
   end
 end
 
-class FrontManServer < Sinatra::Base
-  set :port, 4568
+class FrontmanServer < Sinatra::Base
+  port = Frontman::Config.get(:port, fallback: 4568)
+  num_retries = Frontman::Config.get(:port_retries, fallback: 3)
+
+  port_retry_strategy = Frontman::Config.get(:port_retry_strategy, ->(port_num){
+    port_in_use = false
+
+    (1 + num_retries).times do
+      begin
+        port_in_use = Socket.tcp("localhost", port_num, connect_timeout: 3) { true }
+      rescue SocketError
+        port_in_use = false
+      end
+
+      break unless port_in_use
+
+      port_num += 1 
+    end
+
+    raise Frontman::ServerPortError if port_in_use
+
+    port_num
+  })
+
+  port = port_retry_strategy.call(port)
+
+  set :port, port
+
   set :server_settings,
       # Avoid having webrick displaying logs for every requests to the serve
       AccessLog: [],

--- a/lib/frontman/errors.rb
+++ b/lib/frontman/errors.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 module Frontman
-  
   class Error < StandardError; end
 
   class DuplicateResourceError < StandardError
@@ -25,8 +26,8 @@ module Frontman
 
   class ServerPortError < StandardError
     def initialize
-      super("Server failed to attach to port. Please shutdown some processes or increase the :port_retries configuration variable.")
+      super('Server failed to attach to port. Please shutdown some processes
+             or increase the :port_retries configuration variable.')
     end
   end
-
 end

--- a/lib/frontman/errors.rb
+++ b/lib/frontman/errors.rb
@@ -1,0 +1,32 @@
+module Frontman
+  
+  class Error < StandardError; end
+
+  class DuplicateResourceError < StandardError
+    def self.create(resource, url, existing_resource)
+      new("Unable to add #{resource.file_path} as #{url}.
+           Resource #{existing_resource.file_path} already exists on this URL.")
+    end
+  end
+
+  class ExistingRedirectError < StandardError
+    def self.create(resource, url)
+      new("Unable to add #{resource.file_path} as #{url}.
+           A redirect already exists for this URL.")
+    end
+  end
+
+  class ExistingResourceError < StandardError
+    def self.create(url, resource)
+      new("Unable to redirect for #{url},
+           the resource #{resource.file_path} already exists on this URL")
+    end
+  end
+
+  class ServerPortError < StandardError
+    def initialize
+      super("Server failed to attach to port. Please shutdown some processes or increase the :port_retries configuration variable.")
+    end
+  end
+
+end

--- a/lib/frontman/sitemap_tree.rb
+++ b/lib/frontman/sitemap_tree.rb
@@ -194,5 +194,4 @@ module Frontman
       "SitemapTree: #{@resource ? @resource.destination_path : @url_part}"
     end
   end
-
 end

--- a/lib/frontman/sitemap_tree.rb
+++ b/lib/frontman/sitemap_tree.rb
@@ -195,17 +195,4 @@ module Frontman
     end
   end
 
-  class DuplicateResourceError < StandardError
-    def self.create(resource, url, existing_resource)
-      new("Unable to add #{resource.file_path} as #{url}.
-           Resource #{existing_resource.file_path} already exists on this URL.")
-    end
-  end
-
-  class ExistingRedirectError < StandardError
-    def self.create(resource, url)
-      new("Unable to add #{resource.file_path} as #{url}.
-           A redirect already exists for this URL.")
-    end
-  end
 end


### PR DESCRIPTION
Solves #1 

Configurable Options: (default values are shown in examples)

```ruby
Frontman::Config.set(:port, 4568)

Frontman::Config.set(:port_retry_strategy, ->(port_num){
  ...retry_logic...

  port_num
})
```

No tests yet, waiting for feedback.