### PR TITLE
Add support for --force flag on frontman init command

### DIFF
--- a/lib/frontman/commands/init.rb
+++ b/lib/frontman/commands/init.rb
@@ -16,7 +16,7 @@ module Frontman
 
       target_dir = File.join(Dir.pwd, path == '.' ? '' : path)
 
-      unless !options[:force].nil? || allowed_to_modify_dir?(target_dir)
+      unless options[:force] || allowed_to_modify_dir?(target_dir)
         say 'Not bootstrapping new Frontman project'
         return
       end

--- a/lib/frontman/commands/init.rb
+++ b/lib/frontman/commands/init.rb
@@ -6,6 +6,7 @@ require 'thor'
 module Frontman
   class CLI < Thor
     option :template
+    option :force
     desc 'init', 'Bootstrap a new Frontman project'
     def init(path)
       template = options[:template] || 'default'
@@ -15,7 +16,7 @@ module Frontman
 
       target_dir = File.join(Dir.pwd, path == '.' ? '' : path)
 
-      unless allowed_to_modify_dir?(target_dir)
+      unless allowed_to_modify_dir?(target_dir) || options[:force].present?
         say 'Not bootstrapping new Frontman project'
         return
       end

--- a/lib/frontman/commands/init.rb
+++ b/lib/frontman/commands/init.rb
@@ -16,7 +16,7 @@ module Frontman
 
       target_dir = File.join(Dir.pwd, path == '.' ? '' : path)
 
-      unless allowed_to_modify_dir?(target_dir) || options[:force].present?
+      unless !options[:force].nil? || allowed_to_modify_dir?(target_dir)
         say 'Not bootstrapping new Frontman project'
         return
       end

--- a/lib/frontman/commands/init.rb
+++ b/lib/frontman/commands/init.rb
@@ -6,7 +6,7 @@ require 'thor'
 module Frontman
   class CLI < Thor
     option :template
-    option :force
+    option :force, type: :boolean
     desc 'init', 'Bootstrap a new Frontman project'
     def init(path)
       template = options[:template] || 'default'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes

## Description

This adds support for a `--force` flag when running `frontman init`. This allows frontman to be installed into a directory which contains a `.git` folder for example.

## Tested

I couldn't find a test around this file in `/spec`, but if you'd like to point me in the right direction I'm happy to help. In the interim I built the gem locally & tested it by running it a few times:

![image](https://user-images.githubusercontent.com/325384/92025654-c7e78d00-ed57-11ea-80a0-95c3b4d12333.png)
