### PR TITLE
Adding source to templates Gemfile files

### DIFF
--- a/project-templates/default/Gemfile
+++ b/project-templates/default/Gemfile
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
+source 'https://rubygems.org'
+
 gem 'frontman-ssg'

--- a/project-templates/webpack/Gemfile
+++ b/project-templates/webpack/Gemfile
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
+source 'https://rubygems.org'
+
 gem 'frontman-ssg'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no

## Description

I setup a frontman project on a clean machine & saw the error:

![image](https://user-images.githubusercontent.com/325384/92618821-a8e97d80-f2b8-11ea-972f-78b4f3a3fb07.png)

When a ran bundle from within the VM I saw:

```text
bash-5.0# bundle
Your Gemfile has no gem server sources. If you need gems that are not already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find gem 'frontman-ssg' in any of the gem sources listed in your Gemfile.
```

It looks like the default template didn't have the source, so I added it.

## Tested

I added the source line to my project & `bundle` installed the gem as expected.
