### PR TITLE
fix: bug with nested content_for

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,8 @@ Metrics/MethodLength:
     - 'lib/frontman/builder/builder.rb'
     - 'lib/frontman/commands/**/*'
     - 'lib/frontman/resource.rb'
+    - 'lib/frontman/context.rb'
+    - 'lib/frontman/helpers/render_helper.rb'
 
 Metrics/AbcSize:
   Exclude:

--- a/lib/frontman/helpers/render_helper.rb
+++ b/lib/frontman/helpers/render_helper.rb
@@ -22,7 +22,17 @@ module RenderHelper
     r = Frontman::Resource.from_path(
       File.join(partial_dir, template), nil, false
     )
-    r.render(nil, data)
+
+    # While rendering, if there's no current page we set it to to the resource
+    # This allows using `content_for` directives in partials
+    current_page = Frontman::App.instance.current_page
+    Frontman::App.instance.current_page = r if current_page.nil?
+
+    content = r.render(nil, data)
+
+    Frontman::App.instance.current_page = current_page
+
+    content
   end
 
   sig do

--- a/lib/frontman/renderers/erb_renderer.rb
+++ b/lib/frontman/renderers/erb_renderer.rb
@@ -6,6 +6,11 @@ require 'frontman/renderers/renderer'
 
 module Frontman
   class ErbRenderer < Frontman::Renderer
+    def initialize
+      @buffer = {}
+      super
+    end
+
     def compile(layout)
       Erubis::Eruby.new(layout, bufvar: '@_erbout')
     end
@@ -23,13 +28,15 @@ module Frontman
 
       return unless buffer
 
-      @buffer = buffer
+      @buffer[context.buffer_hash] = buffer
       context.instance_variable_set(:@_erbout, '')
     end
 
     def restore_buffer(context)
-      context.instance_variable_set(:@_erbout, @buffer) if @buffer
-      @buffer = nil
+      return unless @buffer[context.buffer_hash]
+
+      context.instance_variable_set(:@_erbout, @buffer[context.buffer_hash])
+      @buffer.delete(context.buffer_hash)
     end
 
     def load_buffer(context)

--- a/lib/frontman/renderers/haml_renderer.rb
+++ b/lib/frontman/renderers/haml_renderer.rb
@@ -8,6 +8,7 @@ module Frontman
   class HamlRenderer < Renderer
     def initialize
       Haml::Options.defaults[:format] = :html5
+      @buffer = {}
       super
     end
 
@@ -26,12 +27,11 @@ module Frontman
     end
 
     def save_buffer(context)
-      @buffer = nil
       haml_locals = context.instance_variable_get(:@_haml_locals)
 
       return unless haml_locals
 
-      @buffer = haml_locals[:_hamlout].buffer
+      @buffer[context.buffer_hash] = haml_locals[:_hamlout].buffer
       # empty the buffer so we can capture everything from the new render
       haml_locals[:_hamlout].buffer = ''
       context.instance_variable_set(:@_haml_locals, haml_locals)
@@ -42,9 +42,9 @@ module Frontman
 
       return unless haml_locals
 
-      haml_locals[:_hamlout].buffer = @buffer
+      haml_locals[:_hamlout].buffer = @buffer[context.buffer_hash]
       context.instance_variable_set(:@_haml_locals, haml_locals)
-      @buffer = nil
+      @buffer.delete(context.buffer_hash)
     end
   end
 end

--- a/spec/frontman/bootstrapper_spec.rb
+++ b/spec/frontman/bootstrapper_spec.rb
@@ -20,7 +20,7 @@ describe Frontman::Bootstrapper do
     it 'should find all resources in a given folder' do
       resources = Frontman::Bootstrapper.resources_from_dir('spec/frontman/mocks')
 
-      expect(resources.size).to eq 16 # Number of non-YAML files in this folder
+      expect(resources.size).to eq 17 # Number of non-YAML files in this folder
     end
   end
 end

--- a/spec/frontman/helpers/render_helper_spec.rb
+++ b/spec/frontman/helpers/render_helper_spec.rb
@@ -38,6 +38,13 @@ describe RenderHelper do
       expect(subject.partial('paragraph.haml', text: 'Testing'))
         .to eq("<p>\nThe passed text: Testing\n</p>\n")
     end
+
+    it 'should handle content_for in partials' do
+      Frontman::Config.set(:partial_dir, 'spec/frontman/mocks/partials')
+
+      expect(subject.partial('content_for.haml'))
+        .to eq("<ul>\n<li>\nNested `content_for` block\n\n</li>\n\n<li>\nThis is a test!\n</li>\n</ul>\n")
+    end
   end
 
   context 'render page' do

--- a/spec/frontman/mocks/partials/content_for.haml
+++ b/spec/frontman/mocks/partials/content_for.haml
@@ -1,0 +1,10 @@
+- content_for :test_data do
+  - content_for :item_text do
+    Nested `content_for` block
+  %li
+    = yield_content :item_text
+
+%ul
+  = yield_content :test_data
+  %li
+    This is a test!


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no

## Description
This fixes an issue when we call `content_for` within a `content_for` block when using HAML. The issue arises from each block using the same `Context` class. This meant that it's trying to access the same buffer, and the second `content_for` block resets the buffer, resulting in an empty buffer for the first `content_for` block, and therefore no content.

We fixed this by keeping track of a buffer hash for each time we need to save, retrieve, and empty the buffer.

## Tested
See tests in `spec/frontman/helpers/render_helper_spec.rb`.

