### PR TITLE
chore: add Ruby 3 to testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,4 +39,4 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby_version: ["2.3", "2.4", "2.5", "2.6", "2.7"]
+              ruby_version: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,4 +39,4 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby_version: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
+              ruby_version: ["2.4", "2.5", "2.6", "2.7", "3.0"]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.3
   Exclude:
     - '**/Rakefile'
     - 'vendor/**/*'
@@ -18,7 +17,7 @@ Style/Documentation:
     - 'lib/**/*'
     - 'project-templates/**/*'
 
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Exclude:
     - 'lib/**/*'
 
@@ -48,6 +47,7 @@ Style/ClassVars:
     - 'lib/frontman/config.rb'
     - 'lib/frontman/resource.rb'
     - 'lib/frontman/data_store_file.rb'
+    - 'spec/frontman/sitemap_tree_spec.rb'
 
 Metrics/ClassLength:
   Exclude:
@@ -75,7 +75,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - '*.gemspec'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
   Exclude:
     - 'frontman-ssg.gemspec'
@@ -91,6 +91,6 @@ Metrics/ParameterLists:
   Exclude:
     - 'lib/frontman/app.rb'
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'lib/frontman/commands/serve.rb'

--- a/frontman-ssg.gemspec
+++ b/frontman-ssg.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |s|
   # Development tools
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rspec', '~> 3.8'
-  s.add_development_dependency 'rubocop', '~> 0.71.0'
-  s.add_development_dependency 'rubocop-performance', '~> 1.3.0'
+  s.add_development_dependency 'rubocop', '~> 0.93.1'
   s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'sorbet', '0.5.6198'
 

--- a/frontman-ssg.gemspec
+++ b/frontman-ssg.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables           = ['frontman']
 
   # Min Ruby version
-  s.required_ruby_version = '>= 2.3.0', '<= 4'
+  s.required_ruby_version = '>= 2.4.0', '<= 4'
 
   # Development tools
   s.add_development_dependency 'rake', '~> 12.3'

--- a/frontman-ssg.gemspec
+++ b/frontman-ssg.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables           = ['frontman']
 
   # Min Ruby version
-  s.required_ruby_version = '~> 2', '>= 2.3.0'
+  s.required_ruby_version = '~> 3.0', '>= 2.3.0'
 
   # Development tools
   s.add_development_dependency 'rake', '~> 12.3'

--- a/frontman-ssg.gemspec
+++ b/frontman-ssg.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables           = ['frontman']
 
   # Min Ruby version
-  s.required_ruby_version = '~> 3.0', '>= 2.3.0'
+  s.required_ruby_version = '>= 2.3.0', '<= 4'
 
   # Development tools
   s.add_development_dependency 'rake', '~> 12.3'

--- a/lib/frontman/custom_struct.rb
+++ b/lib/frontman/custom_struct.rb
@@ -5,7 +5,7 @@ require 'ostruct'
 
 class CustomStruct < OpenStruct
   def respond_to_missing?(method_id, *_arguments)
-    to_h.respond_to?(method_id) || super(method_id)
+    to_h.respond_to?(method_id) || super
   end
 
   def key?(key)

--- a/spec/spec_setup.rb
+++ b/spec/spec_setup.rb
@@ -2,7 +2,6 @@
 
 require 'rspec'
 require 'simplecov'
-require 'bundler'
 require 'frontman/bootstrapper'
 require 'frontman/app'
 
@@ -12,8 +11,5 @@ end
 
 # encoding: utf-8
 $LOAD_PATH << File.expand_path('..', __dir__)
-
-# Pull in all of the gems including those in the `test` group
-Bundler.require :default, :test, :development, :debug
 
 Frontman::Bootstrapper.bootstrap_app(Frontman::App.instance)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes/no
| Related issue     | fix #46 

## Description
This PR adds Ruby v3 to the testing matrix to ensure Ruby 3 support.

